### PR TITLE
Bug Fixes

### DIFF
--- a/adk/ADK.py
+++ b/adk/ADK.py
@@ -94,7 +94,7 @@ class ADK(object):
 
     def init(self, local_payload=None, pprint=print):
         self.load()
-        if self.is_local and local_payload:
+        if self.is_local and local_payload is not None:
             if self.loading_exception:
                 load_error = create_exception(self.loading_exception, loading_exception=True)
                 self.write_to_pipe(load_error, pprint=pprint)


### PR DESCRIPTION
This PR has the following changes:
* bugfix for Manifest based workflows, where a `fail_on_tamper` may be set to true, but no frozen manifest file is found.
* bugfix for ADK algorithms where the init function may have a `local_payload` value that's not None, but validates as False such as "" and {}; adjusted to be more explicit.