### PR TITLE
ALGO-62 Integrated mlops agent

### DIFF
--- a/adk/ADK.py
+++ b/adk/ADK.py
@@ -3,7 +3,6 @@ import json
 import os
 import sys
 import Algorithmia
-import yaml
 import os
 import subprocess
 

--- a/adk/mlops.py
+++ b/adk/mlops.py
@@ -1,36 +1,44 @@
 import yaml
+import json
 import os
 import subprocess
 
 
-class MLOps(Object):
-    def __init__(self, endpoint, api_token, model_id, deployment_id):
+class MLOps(object):
+    spool_dir = "/tmp/ta"
+    agent_dir = "/opt/mlops-agent/datarobot_mlops_package-8.1.2"
+
+    def __init__(self, api_token, path):
         self.token = api_token
-        self.endpoint = endpoint
-        self.model_id = model_id
-        self.deployment_id = deployment_id
-        self.spool_dir = "/tmp/ta"
-        self.agent_dir = "/opt/mlops-agent/datarobot_mlops_package-8.1.2"
+        if os.path.exists(path):
+            with open(path) as f:
+                mlops_config = json.load(f)
+        else:
+            raise Exception("'mlops.json' file does not exist, but mlops was requested.")
+        if not os.path.exists(agent_dir):
+            raise Exception("environment is not configured for mlops.\nPlease select a valid mlops enabled environment.")
+        self.endpoint = mlops_config['datarobot_api_endpoint']
+        self.model_id = mlops_config['model_id']
+        self.deployment_id = mlops_config['deployment_id']
 
     def init(self):
-        with open(f'{self.agent_dir}/conf/mlops.agent.conf.yaml') as f:
-            documents = yaml.load(f, Loader=yaml.FullLoader)
-        documents['mlopsUrl'] = self.endpoint
-        documents['apiToken'] = self.token
-        with open(f'{agents_dir}/conf/mlops.agent.conf.yaml', 'w') as f:
-            yaml.dump(documents, f)
-
-        subprocess.call(f'{agents_dir}/bin/start-agent.sh')
-        check = subprocess.Popen([f'{agents_dir}/bin/status-agent.sh'], stdout=subprocess.PIPE)
-        output = check.stdout.readlines()
-        check.terminate()
-        if "DataRobot MLOps-Agent is running as a service." in output:
-            return True
-        else:
-            return False
-
-    def env_vars(self):
         os.environ['MLOPS_DEPLOYMENT_ID'] = self.deployment_id
         os.environ['MLOPS_MODEL_ID'] = self.model_id
         os.environ['MLOPS_SPOOLER_TYPE'] = "FILESYSTEM"
         os.environ['MLOPS_FILESYSTEM_DIRECTORY'] = "/tmp/ta"
+
+        with open(f'{self.agent_dir}/conf/mlops.agent.conf.yaml') as f:
+            documents = yaml.load(f, Loader=yaml.FullLoader)
+        documents['mlopsUrl'] = self.endpoint
+        documents['apiToken'] = self.token
+        with open(f'{self.agent_dir}/conf/mlops.agent.conf.yaml', 'w') as f:
+            yaml.dump(documents, f)
+
+        subprocess.call(f'{self.agent_dir}/bin/start-agent.sh')
+        check = subprocess.Popen([f'{self.agent_dir}/bin/status-agent.sh'], stdout=subprocess.PIPE)
+        output = check.stdout.readlines()[0]
+        check.terminate()
+        if b"DataRobot MLOps-Agent is running as a service." in output:
+            return True
+        else:
+            raise Exception(output)

--- a/adk/mlops.py
+++ b/adk/mlops.py
@@ -6,7 +6,8 @@ import subprocess
 
 class MLOps(object):
     spool_dir = "/tmp/ta"
-    agent_dir = "/opt/mlops-agent/datarobot_mlops_package-8.1.2"
+    agent_dir = "/opt/mlops-agent"
+    mlops_dir_name = "datarobot_mlops_package-8.1.2"
 
     def __init__(self, api_token, path):
         self.token = api_token
@@ -15,27 +16,28 @@ class MLOps(object):
                 mlops_config = json.load(f)
         else:
             raise Exception("'mlops.json' file does not exist, but mlops was requested.")
-        if not os.path.exists(agent_dir):
+        if not os.path.exists(self.agent_dir):
             raise Exception("environment is not configured for mlops.\nPlease select a valid mlops enabled environment.")
-        self.endpoint = mlops_config['datarobot_api_endpoint']
+        self.endpoint = mlops_config['datarobot_mlops_service_url']
         self.model_id = mlops_config['model_id']
         self.deployment_id = mlops_config['deployment_id']
+        self.mlops_name = mlops_config.get('mlops_dir_name', 'datarobot_mlops_package-8.1.2')
 
     def init(self):
         os.environ['MLOPS_DEPLOYMENT_ID'] = self.deployment_id
         os.environ['MLOPS_MODEL_ID'] = self.model_id
         os.environ['MLOPS_SPOOLER_TYPE'] = "FILESYSTEM"
-        os.environ['MLOPS_FILESYSTEM_DIRECTORY'] = "/tmp/ta"
+        os.environ['MLOPS_FILESYSTEM_DIRECTORY'] = self.spool_dir
 
-        with open(f'{self.agent_dir}/conf/mlops.agent.conf.yaml') as f:
+        with open(f'{self.agent_dir}/{self.mlops_dir_name}/conf/mlops.agent.conf.yaml') as f:
             documents = yaml.load(f, Loader=yaml.FullLoader)
         documents['mlopsUrl'] = self.endpoint
         documents['apiToken'] = self.token
-        with open(f'{self.agent_dir}/conf/mlops.agent.conf.yaml', 'w') as f:
+        with open(f'{self.agent_dir}/{self.mlops_dir_name}/conf/mlops.agent.conf.yaml', 'w') as f:
             yaml.dump(documents, f)
 
-        subprocess.call(f'{self.agent_dir}/bin/start-agent.sh')
-        check = subprocess.Popen([f'{self.agent_dir}/bin/status-agent.sh'], stdout=subprocess.PIPE)
+        subprocess.call(f'{self.agent_dir}/{self.mlops_dir_name}/bin/start-agent.sh')
+        check = subprocess.Popen([f'{self.agent_dir}/{self.mlops_dir_name}/bin/status-agent.sh'], stdout=subprocess.PIPE)
         output = check.stdout.readlines()[0]
         check.terminate()
         if b"DataRobot MLOps-Agent is running as a service." in output:

--- a/adk/mlops.py
+++ b/adk/mlops.py
@@ -1,0 +1,36 @@
+import yaml
+import os
+import subprocess
+
+
+class MLOps(Object):
+    def __init__(self, endpoint, api_token, model_id, deployment_id):
+        self.token = api_token
+        self.endpoint = endpoint
+        self.model_id = model_id
+        self.deployment_id = deployment_id
+        self.spool_dir = "/tmp/ta"
+        self.agent_dir = "/opt/mlops-agent/datarobot_mlops_package-8.1.2"
+
+    def init(self):
+        with open(f'{self.agent_dir}/conf/mlops.agent.conf.yaml') as f:
+            documents = yaml.load(f, Loader=yaml.FullLoader)
+        documents['mlopsUrl'] = self.endpoint
+        documents['apiToken'] = self.token
+        with open(f'{agents_dir}/conf/mlops.agent.conf.yaml', 'w') as f:
+            yaml.dump(documents, f)
+
+        subprocess.call(f'{agents_dir}/bin/start-agent.sh')
+        check = subprocess.Popen([f'{agents_dir}/bin/status-agent.sh'], stdout=subprocess.PIPE)
+        output = check.stdout.readlines()
+        check.terminate()
+        if "DataRobot MLOps-Agent is running as a service." in output:
+            return True
+        else:
+            return False
+
+    def env_vars(self):
+        os.environ['MLOPS_DEPLOYMENT_ID'] = self.deployment_id
+        os.environ['MLOPS_MODEL_ID'] = self.model_id
+        os.environ['MLOPS_SPOOLER_TYPE'] = "FILESYSTEM"
+        os.environ['MLOPS_FILESYSTEM_DIRECTORY'] = "/tmp/ta"

--- a/adk/modeldata.py
+++ b/adk/modeldata.py
@@ -2,11 +2,10 @@ import os
 import json
 import hashlib
 from adk.classes import FileData
-from adk.mlops import MLOps
 
 
 class ModelData(object):
-    def __init__(self, client, model_manifest_path, mlops=False):
+    def __init__(self, client, model_manifest_path):
         self.manifest_reg_path = model_manifest_path
         self.manifest_frozen_path = "{}.freeze".format(self.manifest_reg_path)
         self.manifest_data = self.get_manifest()
@@ -14,7 +13,6 @@ class ModelData(object):
         self.models = {}
         self.usr_key = "__user__"
         self.using_frozen = True
-        self.use_mlops = mlops
 
     def __getitem__(self, key):
         return getattr(self, self.usr_key + key)
@@ -40,8 +38,6 @@ class ModelData(object):
     def initialize(self):
         if self.client is None:
             raise Exception("Client was not defined, please define a Client when using Model Manifests.")
-        if self.use_mlops:
-            self.mlops_init()
         for required_file in self.manifest_data['required_files']:
             name = required_file['name']
             source_uri = required_file['source_uri']
@@ -109,18 +105,6 @@ class ModelData(object):
             return manifest_data
         else:
             return None
-
-    def mlops_init(self):
-        mlops = self.manifest_data['mlops']
-        model_id = mlops['model_id']
-        deployment_id = mlops['deployment_id']
-        datarobot_api_endpoint = mlops['datarobot_api_endpoint']
-
-        api_token = os.environ.get('DATAROBOT_MLOPS_API_TOKEN')
-        if api_token is None:
-            raise Exception("'DATAROBOT_MLOPS_API_TOKEN' environment variable not found.\nPlease ensure that you have a"
-                            "valid API token and add it as a secret to this algorithm.")
-        self.mlops = MLOps(datarobot_api_endpoint, api_token, model_id, deployment_id)
 
 
 def check_lock(manifest_data):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 algorithmia>=1.7,<2
 six
-pyaml==21.10
+pyaml>=21.10,<21.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 algorithmia>=1.7,<2
 six
+pyaml==21.10

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     author_email='support@algorithmia.com',
     packages=['adk'],
     install_requires=[
+        'pyaml>=21.10,<21.11',
         'six',
     ],
     include_package_data=True,

--- a/tests/AdkTest.py
+++ b/tests/AdkTest.py
@@ -1,7 +1,7 @@
 from adk import ADK
-
+from adk.modeldata import ModelData
 
 class ADKTest(ADK):
     def __init__(self, apply_func, load_func=None, client=None, manifest_path="model_manifest.json.freeze"):
         super(ADKTest, self).__init__(apply_func, load_func, client)
-        self.model_data = self.init_manifest(manifest_path)
+        self.model_data = ModelData(self.client, manifest_path)

--- a/tests/manifests/mlops_model_manifest.json
+++ b/tests/manifests/mlops_model_manifest.json
@@ -1,0 +1,9 @@
+{
+  "mlops": {
+    "model_id": "",
+    "deployment_id": "",
+    "datarobot_api_endpoint": "https://app.datarobot.com"
+  },
+  "required_models": [],
+  "optional_models": []
+}

--- a/tests/manifests/mlops_model_manifest.json
+++ b/tests/manifests/mlops_model_manifest.json
@@ -1,9 +1,0 @@
-{
-  "mlops": {
-    "model_id": "",
-    "deployment_id": "",
-    "datarobot_api_endpoint": "https://app.datarobot.com"
-  },
-  "required_models": [],
-  "optional_models": []
-}


### PR DESCRIPTION
This PR adds the mlops agent client-side interface logic to the ADK. Exposing a `mlops` variable to the `.init()` function.

requires the `environment_validator` in langpacks to validate.

https://github.com/algorithmiaio/langpacks/pull/228 check this out to test

to test:
`./tools/environment_validator.py -g python3 -s python39 -d java11 -d mlops-agent -t dependency -n python39-mlops`
will need to add an environment variable to the template file to validate.
